### PR TITLE
Camera optimisation

### DIFF
--- a/src/main/java/graphics/Camera.java
+++ b/src/main/java/graphics/Camera.java
@@ -84,6 +84,14 @@ public class Camera {
     }
 
     /**
+     * @brief Get the focused Entity.
+     * @return The focused Entity object.
+     */
+    public Entity getFocused() {
+        return singleton.focused;
+    }
+
+    /**
      * @brief Draw image on screen based on focused point.
      * 
      * The image will be drawn with a scale of 1 and no offset.

--- a/src/main/java/graphics/Canvas.java
+++ b/src/main/java/graphics/Canvas.java
@@ -188,16 +188,25 @@ public class Canvas extends JPanel {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
 
-        // TESTING PURPOSE
+        int SCALE = 2;
+        
+        // Get focused coordinates
+        int focusX = this.camera.getFocused() != null ? (int)this.camera.getFocused().getPosition().x : 0;
+        int focusY = this.camera.getFocused() != null ? (int)this.camera.getFocused().getPosition().y : 0;
 
-        int SCALE = isFullscreen ? 4 : 2;
-    
-        for (int i = (int)this.player.getPosition().x / (32 * SCALE) - 9 ; i < (int)this.player.getPosition().x / (32 * SCALE) + 10 ; i++) {
-            for (int j = (int)this.player.getPosition().y / (32 * SCALE) - 6 ; j < (int)this.player.getPosition().y / (32 * SCALE) + 7 ; j++) {
+        // Get tile infos for screen
+        int width = getPreferredSize().width / (this.map.getTileSize() * SCALE);
+        int height = getPreferredSize().height / (this.map.getTileSize() * SCALE);
+
+        // Draw map based on coordinates
+        for (int i = focusX / (this.map.getTileSize() * SCALE) - width / 2 - 1 ; i < focusX / (this.map.getTileSize() * SCALE) + width / 2 + 2 ; i++) {
+            for (int j = focusY / (this.map.getTileSize() * SCALE) - height / 2 - 1 ; j < focusY / (this.map.getTileSize() * SCALE) + height / 2 + 2 ; j++) {
                 this.map.drawTile(this.camera, g, i, j, SCALE);
             }
         }
 
+        // TESTING PURPOSE
+        
         this.camera.drawImage(g, this.player2.getSprite(), this.player2.getPosition().x, this.player2.getPosition().y, SCALE, this.player2.getOffset());
         this.camera.drawImage(g, this.player.getSprite(), this.player.getPosition().x, this.player.getPosition().y, SCALE, this.player.getOffset());
         

--- a/src/main/java/graphics/Canvas.java
+++ b/src/main/java/graphics/Canvas.java
@@ -15,7 +15,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Toolkit;
-import java.awt.image.BufferedImage;
 
 import javax.swing.JPanel;
 import javax.swing.Timer;
@@ -195,11 +194,7 @@ public class Canvas extends JPanel {
     
         for (int i = (int)this.player.getPosition().x / (32 * SCALE) - 9 ; i < (int)this.player.getPosition().x / (32 * SCALE) + 10 ; i++) {
             for (int j = (int)this.player.getPosition().y / (32 * SCALE) - 6 ; j < (int)this.player.getPosition().y / (32 * SCALE) + 7 ; j++) {
-                BufferedImage tile = map.getTile(i, j);
-
-                if (tile != null) {
-                    this.camera.drawImage(g, map.getTile(i, j), i * 32 * SCALE, j * 32 * SCALE, SCALE);
-                }
+                this.map.drawTile(this.camera, g, i, j, SCALE);
             }
         }
 

--- a/src/main/java/map/Map.java
+++ b/src/main/java/map/Map.java
@@ -134,4 +134,12 @@ public class Map {
     private BufferedImage getTileById(int id) {
         return tiles[id - 1];
     }
+
+    /**
+     * @brief Getter function for the tile size.
+     * @return The tile size in pixel units.
+     */
+    public int getTileSize() {
+        return tileSize;
+    }
 }

--- a/src/main/java/map/Map.java
+++ b/src/main/java/map/Map.java
@@ -14,6 +14,7 @@ package map;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 
 
 /**
@@ -24,8 +25,22 @@ import java.io.IOException;
  * @brief This class allows to read a map directory and get tile on position given.
  */
 public class Map {
-    /** @brief Instance of finite state machine that reads the file. */
-    private Reader mapReader;
+    /** @brief Stores all tiles */
+    private BufferedImage[] tiles;
+    /** @brief The map tiles size */
+    private int tileSize;
+    /** @brief The map width in tile unit (tu) */
+    private int width;
+    /** @brief The map height in tile unit (tu) */
+    private int height;
+    /**
+     * @brief The layers.
+     *
+     * The structure is made as follows :
+     * - The **key** is the string representing the layer name.
+     * - The **value** is the array that store the layer's tilemap.
+     */
+    private LinkedHashMap<String, int[]> layers;
 
     /**
      * @brief Map constructor.
@@ -38,12 +53,43 @@ public class Map {
      * @warning If something is wrong with the map directory, it will log an error but raise it.
      */
     public Map(String mapDir) {
+        Reader mapReader;
         // Load map using reader class
         try {
             mapReader = new Reader(mapDir);
         } catch (IOException e) {
             System.out.println(e);
             return;
+        }
+
+        // Get all basic info
+        tileSize = mapReader.getTileSize();
+        width = mapReader.getWidth();
+        height = mapReader.getHeight();
+        layers = mapReader.getLayers();
+
+        // ---- Split tilesets ----
+
+        // Get number of tiles and create array
+        int last_index = mapReader.getTilesets().lastEntry().getKey();
+        int last_height = mapReader.getTilesets().lastEntry().getValue().getHeight();
+        int last_width = mapReader.getTilesets().lastEntry().getValue().getWidth();
+
+        tiles = new BufferedImage[last_index + last_height * last_width / (tileSize * tileSize) - 1];
+
+        // Loop through all tilesets
+        for (var entry : mapReader.getTilesets().entrySet()) {
+            // Define array initial index
+            int k = entry.getKey() - 1;
+            
+            // Loop through current tileset
+            for (int i = 0 ; i < entry.getValue().getHeight() / tileSize ; i++) {
+                for (int j = 0 ; j < entry.getValue().getWidth() / tileSize ; j++) {
+                    // Add tile to tile array
+                    tiles[k] = entry.getValue().getSubimage(j * tileSize, i * tileSize, tileSize, tileSize);
+                    k++;
+                }
+            }
         }
     }
 
@@ -59,17 +105,17 @@ public class Map {
      */
     public BufferedImage getTile(int x, int y) {
         // Check if coordinates are ok
-        if (x >= mapReader.getWidth() || y >= mapReader.getHeight() || x < 0 || y < 0) {
+        if (x >= width || y >= height || x < 0 || y < 0) {
             return null;
         }
-        int tileCoordinate = y * mapReader.getWidth() + x;
+        int tileCoordinate = y * width + x;
         
         // Create tile and painter
-        BufferedImage finalTile = new BufferedImage(mapReader.getTileSize(), mapReader.getTileSize(), BufferedImage.TYPE_INT_ARGB);
+        BufferedImage finalTile = new BufferedImage(tileSize, tileSize, BufferedImage.TYPE_INT_ARGB);
         Graphics2D painter = finalTile.createGraphics();
         
         // Get all layers done
-        for (int[] layer : mapReader.getLayers().values()) {
+        for (int[] layer : layers.values()) {
             int tileIdForLayer = layer[tileCoordinate];
             if (tileIdForLayer != 0) {
                 painter.drawImage(getTileById(tileIdForLayer), null, 0, 0);
@@ -86,32 +132,6 @@ public class Map {
      * @return The tile in the tileset corresponding to the given id.
      */
     private BufferedImage getTileById(int id) {
-        int actualIndex = 0;
-        BufferedImage tileset = null;
-
-        // Check all tilesets
-        for (var entry : mapReader.getTilesets().entrySet()) {
-            // 
-            if (entry.getKey() < id) {
-                actualIndex = id - entry.getKey();
-                tileset = entry.getValue();
-            } else {
-                break;
-            }
-        }
-
-        // Compute coordinate on tileset
-        int x = actualIndex % (tileset.getWidth() / mapReader.getTileSize());
-        int y = actualIndex / (tileset.getWidth() / mapReader.getTileSize());
-
-        // Get tile
-        BufferedImage tile = null;
-
-        try {
-            tile = tileset.getSubimage(x * mapReader.getTileSize(), y * mapReader.getTileSize(), mapReader.getTileSize(), mapReader.getTileSize());
-        } catch (Exception e) {
-        }
-
-        return tile;
+        return tiles[id - 1];
     }
 }

--- a/src/main/java/map/Map.java
+++ b/src/main/java/map/Map.java
@@ -11,10 +11,12 @@
 
 package map;
 
-import java.awt.Graphics2D;
+import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.LinkedHashMap;
+
+import graphics.Camera;
 
 
 /**
@@ -99,31 +101,29 @@ public class Map {
      * When a tile is asked, it will compute all the layers and return
      * the final tile.
      * 
+     * @param cam The camera on which to draw the tile.
+     * @param g The graphics object on which to draw tile.
      * @param x The x coordinate in the map grid.
      * @param y The y coordinate in the map grid.
+     * @param scale The scale of the drawn tile.
      * @return The computed tile.
      */
-    public BufferedImage getTile(int x, int y) {
+    public boolean drawTile(Camera cam, Graphics g, int x, int y, double scale) {
         // Check if coordinates are ok
         if (x >= width || y >= height || x < 0 || y < 0) {
-            return null;
+            return false;
         }
         int tileCoordinate = y * width + x;
-        
-        // Create tile and painter
-        BufferedImage finalTile = new BufferedImage(tileSize, tileSize, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D painter = finalTile.createGraphics();
         
         // Get all layers done
         for (int[] layer : layers.values()) {
             int tileIdForLayer = layer[tileCoordinate];
             if (tileIdForLayer != 0) {
-                painter.drawImage(getTileById(tileIdForLayer), null, 0, 0);
+                cam.drawImage(g, getTileById(tileIdForLayer), x * this.tileSize * scale, y * this.tileSize * scale, scale);
             }
         }
 
-        painter.dispose();
-        return finalTile;
+        return true;
     }
 
     /**


### PR DESCRIPTION
While loading the map, we load the tilesets then proceed to cut every tile and store them in memory.
- Cutting tile access time from $O(k + c)$ where $k$ is the number of tilesets and $c$ the time needed to perform sub image operation down to $O(1)$ (quite faster yes).
- We store a bit much information in RAM but the difference is not big.

Get rid of Reader attribute, now only local when constructing Map object : reducing space complexity as well.